### PR TITLE
完善git泄漏误报，完善Mongo未授权访问的判断逻辑

### DIFF
--- a/exploits/website/git_information_disclosure.py
+++ b/exploits/website/git_information_disclosure.py
@@ -5,22 +5,26 @@
 # @Last Modified by:   Lcy
 # @Last Modified time: 2016-09-26 16:44:10
 import urllib2
+
+
 class Exploit:
-    def __init__(self,target,expfile):
+    def __init__(self, target, expfile):
         self.target = target
         self.result = {
             "name": "Git information disclosure",
             "author": "Lcy",
             "type": "website",
             "ref": "http://phpinfo.me",
-            "status":False,
-            "info":"",
-            'filename':expfile,
-            "target":target,
+            "status": False,
+            "info": "",
+            'filename': expfile,
+            "target": target,
         }
+
     def verify(self):
-        keyword = ['core','remote','branch']
+        keyword = ['core', 'remote', 'branch']
         vul_url = self.target + '/.git/config'
+        false_url = self.target + '/.git/configFalse_False_90909'
         resquest = urllib2.Request(vul_url)
         response = urllib2.urlopen(resquest)
         if response.getcode() != 200:
@@ -32,5 +36,10 @@ class Exploit:
                 flag = True
                 break
         if flag == True:
-            self.result['status'] = True
-            self.result['info'] = "目标存在git泄露漏洞,验证url:%s" % vul_url
+            resquest = urllib2.Request(false_url)
+            response = urllib2.urlopen(resquest)
+            if response.getcode() != 200:  # 假如对方的网站很变态什么都返回 200并且返回的内容中恰好含有关键字
+                self.result['status'] = True
+                self.result['info'] = "目标存在git泄露漏洞,验证url:%s" % vul_url
+            else:
+                return

--- a/exploits/website/mongodb_remote.py
+++ b/exploits/website/mongodb_remote.py
@@ -5,30 +5,53 @@
 # @Last Modified by:   Lcy
 # @Last Modified time: 2016-09-26 17:38:36
 import socket
-from lib.util import url2ip
+#from lib.util import url2ip
+import pymongo
+import binascii
+
+
 class Exploit:
-    def __init__(self,target,expfile):
+    def __init__(self, target,expfile):
         self.target = target
+
         self.result = {
             "name": "Mongodb未授权访问",
             "author": "Lcy",
             "type": "website",
             "ref": "https://phpinfo.me",
-            "status":False,
-            "info":"",
-            'filename':expfile,
-            "target":target,
+            "status": False,
+            "info": "",
+            'filename': expfile,
+            "target": target,
         }
-    def verify(self):
-        s = socket.socket()
-        socket.setdefaulttimeout(5)
+    def check(self,ip, port, timeout):
+        # from https://github.com/ysrc/xunfeng/blob/4f93adc8ffb4eb77e0f1fe19704cdf984485ccea/vulscan/vuldb/crack_mongo.py
         try:
-            host = url2ip(self.target)
-            port = 27017
-            s.connect((host, port))
-            self.result['status'] = True
-            self.result['info'] = '%s目标开放Mongodb端口' % self.target
-        except Exception,e:
+            socket.setdefaulttimeout(timeout)
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect((ip, int(port)))
+            data = binascii.a2b_hex(
+                "3a000000a741000000000000d40700000000000061646d696e2e24636d640000000000ffffffff130000001069736d6173746572000100000000")
+            s.send(data)
+            result = s.recv(1024)
+            if "ismaster" in result:
+                getlog_data = binascii.a2b_hex(
+                    "480000000200000000000000d40700000000000061646d696e2e24636d6400000000000100000021000000026765744c6f670010000000737461727475705761726e696e67730000")
+                s.send(getlog_data)
+                result = s.recv(1024)
+                if "totalLinesWritten" in result:
+                    return True
+        except Exception, e:
             pass
-        s.close()
-       
+
+    def verify(self):
+        try:
+            #host = url2ip(self.target)
+            host='122.0.0.1'
+            port = 27017
+            if self.check(host, port, timeout=5):
+                self.result['status'] = True
+                self.result['info'] = '% Mongo未授权访问' % self.target
+        except Exception as e:
+            print e
+            pass


### PR DESCRIPTION
# 1. Mongo未授权访问验证
现有的Mongo未授权访问判断应该是存在问题的，借用了巡风的POC，来完成对Mongo未授权访问的验证
# 2. .git 泄漏的完善
其实不仅仅是.git泄漏，在实际的扫描中，发现有写很变态的网站访问不存在的页面仍然返回200状态码，如果此时HTML页面中刚好含有关键字，那么会产生误报。解决办法是在发现访问.git/config 之后再访问一下一个不存在的URL，如果依旧返回200状态码的话则判断为不存在.git 路径泄漏